### PR TITLE
[hotfix] Fix agent saying "silence"

### DIFF
--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -229,7 +229,7 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
                 return ssml_fragment.split(">")[-1]
         return message
 
-    async def create_speech(
+    async def create_speech_uncached(
         self,
         message: BaseMessage,
         chunk_size: int,
@@ -294,5 +294,3 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
                 message.text, ssml, seconds, word_boundary_event_pool
             ),
         )
-
-    create_speech_uncached = create_speech


### PR DESCRIPTION
We override `create_speech` in the Azure synthesizer, so we don't dispatch into `BaseSynthesizer.create_speech`, which is necessary

In the future, we should probably allow users to override `create_speech`, and then call our method `create_speech_with_cache`